### PR TITLE
Add overdue notification processing

### DIFF
--- a/src/LibraryLending.Application/Services/INotificationService.cs
+++ b/src/LibraryLending.Application/Services/INotificationService.cs
@@ -1,0 +1,9 @@
+using LibraryLending.Domain.Entities;
+
+namespace LibraryLending.Application.Services;
+
+public interface INotificationService
+{
+    Task SendOverdueNotificationAsync(Patron patron, Loan loan, CancellationToken cancellationToken = default);
+}
+

--- a/src/LibraryLending.Application/UseCases/Notifications/SendOverdueNotifications/SendOverdueNotificationsCommand.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/SendOverdueNotifications/SendOverdueNotificationsCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.SendOverdueNotifications;
+
+public record SendOverdueNotificationsCommand() : IRequest;
+

--- a/src/LibraryLending.Application/UseCases/Notifications/SendOverdueNotifications/SendOverdueNotificationsHandler.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/SendOverdueNotifications/SendOverdueNotificationsHandler.cs
@@ -1,0 +1,56 @@
+using LibraryLending.Application.Services;
+using LibraryLending.Domain.Entities;
+using LibraryLending.Domain.Repositories;
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.SendOverdueNotifications;
+
+public class SendOverdueNotificationsHandler : IRequestHandler<SendOverdueNotificationsCommand>
+{
+    private readonly ILoanRepository _loanRepository;
+    private readonly IOverdueNotificationRepository _notificationRepository;
+    private readonly INotificationService _notificationService;
+
+    public SendOverdueNotificationsHandler(
+        ILoanRepository loanRepository,
+        IOverdueNotificationRepository notificationRepository,
+        INotificationService notificationService)
+    {
+        _loanRepository = loanRepository;
+        _notificationRepository = notificationRepository;
+        _notificationService = notificationService;
+    }
+
+    public async Task<Unit> Handle(SendOverdueNotificationsCommand request, CancellationToken cancellationToken)
+    {
+        var loans = await _loanRepository.GetAllActiveAsync(cancellationToken);
+
+        foreach (var loan in loans.Where(l => l.IsOverdue))
+        {
+            var notification = await _notificationRepository.GetByLoanIdAsync(loan.Id, cancellationToken);
+            if (notification != null && notification.Status == NotificationStatus.Sent)
+                continue;
+
+            var isNew = notification == null;
+            notification ??= new OverdueNotification(loan.Id, loan.PatronId);
+
+            try
+            {
+                await _notificationService.SendOverdueNotificationAsync(loan.Patron, loan, cancellationToken);
+                notification.MarkSent(DateTime.UtcNow);
+            }
+            catch
+            {
+                notification.RecordFailure(DateTime.UtcNow);
+            }
+
+            if (isNew)
+                await _notificationRepository.AddAsync(notification, cancellationToken);
+            else
+                await _notificationRepository.UpdateAsync(notification, cancellationToken);
+        }
+
+        return Unit.Value;
+    }
+}
+

--- a/src/LibraryLending.Domain/Entities/OverdueNotification.cs
+++ b/src/LibraryLending.Domain/Entities/OverdueNotification.cs
@@ -1,0 +1,61 @@
+using System.Collections.ObjectModel;
+
+namespace LibraryLending.Domain.Entities;
+
+public class OverdueNotification
+{
+    public Guid Id { get; private set; }
+    public Guid LoanId { get; private set; }
+    public Guid PatronId { get; private set; }
+    public NotificationStatus Status { get; private set; }
+    public IReadOnlyCollection<NotificationHistory> History => _history.AsReadOnly();
+
+    private readonly List<NotificationHistory> _history = new();
+
+    // EF Core constructor
+    private OverdueNotification() { }
+
+    public OverdueNotification(Guid loanId, Guid patronId)
+    {
+        Id = Guid.NewGuid();
+        LoanId = loanId;
+        PatronId = patronId;
+        Status = NotificationStatus.Pending;
+    }
+
+    public void MarkSent(DateTime date)
+    {
+        Status = NotificationStatus.Sent;
+        _history.Add(new NotificationHistory(date, NotificationStatus.Sent));
+    }
+
+    public void RecordFailure(DateTime date)
+    {
+        _history.Add(new NotificationHistory(date, NotificationStatus.Failed));
+    }
+}
+
+public enum NotificationStatus
+{
+    Pending = 0,
+    Sent = 1,
+    Failed = 2
+}
+
+public class NotificationHistory
+{
+    public Guid Id { get; private set; }
+    public DateTime Date { get; private set; }
+    public NotificationStatus Status { get; private set; }
+
+    // EF Core constructor
+    private NotificationHistory() { }
+
+    public NotificationHistory(DateTime date, NotificationStatus status)
+    {
+        Id = Guid.NewGuid();
+        Date = date;
+        Status = status;
+    }
+}
+

--- a/src/LibraryLending.Domain/Repositories/ILoanRepository.cs
+++ b/src/LibraryLending.Domain/Repositories/ILoanRepository.cs
@@ -6,6 +6,7 @@ public interface ILoanRepository
 {
     Task<Loan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Loan>> GetActiveLoansForPatronAsync(Guid patronId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Loan>> GetAllActiveAsync(CancellationToken cancellationToken = default);
     Task AddAsync(Loan loan, CancellationToken cancellationToken = default);
     Task UpdateAsync(Loan loan, CancellationToken cancellationToken = default);
 }

--- a/src/LibraryLending.Domain/Repositories/IOverdueNotificationRepository.cs
+++ b/src/LibraryLending.Domain/Repositories/IOverdueNotificationRepository.cs
@@ -1,0 +1,11 @@
+using LibraryLending.Domain.Entities;
+
+namespace LibraryLending.Domain.Repositories;
+
+public interface IOverdueNotificationRepository
+{
+    Task<OverdueNotification?> GetByLoanIdAsync(Guid loanId, CancellationToken cancellationToken = default);
+    Task AddAsync(OverdueNotification notification, CancellationToken cancellationToken = default);
+    Task UpdateAsync(OverdueNotification notification, CancellationToken cancellationToken = default);
+}
+

--- a/src/LibraryLending.Infrastructure/Repositories/LoanRepository.cs
+++ b/src/LibraryLending.Infrastructure/Repositories/LoanRepository.cs
@@ -32,6 +32,15 @@ public class LoanRepository : ILoanRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IEnumerable<Loan>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Loans
+            .Include(l => l.Book)
+            .Include(l => l.Patron)
+            .Where(l => l.ReturnedAt == null)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task AddAsync(Loan loan, CancellationToken cancellationToken = default)
     {
         _context.Loans.Add(loan);

--- a/tests/LibraryLending.Application.Tests/UseCases/Notifications/SendOverdueNotificationsHandlerTests.cs
+++ b/tests/LibraryLending.Application.Tests/UseCases/Notifications/SendOverdueNotificationsHandlerTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using LibraryLending.Application.Services;
+using LibraryLending.Application.UseCases.Notifications.SendOverdueNotifications;
+using LibraryLending.Domain.Entities;
+using LibraryLending.Domain.Repositories;
+using LibraryLending.Domain.ValueObjects;
+using Moq;
+
+namespace LibraryLending.Application.Tests.UseCases.Notifications;
+
+public class SendOverdueNotificationsHandlerTests
+{
+    private static Loan CreateOverdueLoan()
+    {
+        var book = new Book(Isbn.Create("9780134685991"), "Test", "Author", 1);
+        var patron = new Patron("Test Patron", Email.Create("test@example.com"));
+        var loan = new Loan(book.Id, patron.Id, DateTime.UtcNow.AddDays(-15));
+        loan.GetType().GetProperty("Book")!.SetValue(loan, book);
+        loan.GetType().GetProperty("Patron")!.SetValue(loan, patron);
+        return loan;
+    }
+
+    [Fact]
+    public async Task ShouldSendNotificationAndRecordHistory_WhenLoanIsOverdue()
+    {
+        var loan = CreateOverdueLoan();
+        var loanRepository = new InMemoryLoanRepository(new[] { loan });
+        var notificationRepository = new InMemoryNotificationRepository();
+        var notificationService = new Mock<INotificationService>();
+        notificationService.Setup(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new SendOverdueNotificationsHandler(loanRepository, notificationRepository, notificationService.Object);
+
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+
+        notificationService.Verify(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()), Times.Once);
+        notificationRepository.Notifications.Should().HaveCount(1);
+        var record = notificationRepository.Notifications.Single();
+        record.Status.Should().Be(NotificationStatus.Sent);
+        record.History.Should().HaveCount(1);
+        record.History.First().Status.Should().Be(NotificationStatus.Sent);
+    }
+
+    [Fact]
+    public async Task ShouldRetryNotification_WhenSendingFailsTemporarily()
+    {
+        var loan = CreateOverdueLoan();
+        var loanRepository = new InMemoryLoanRepository(new[] { loan });
+        var notificationRepository = new InMemoryNotificationRepository();
+        var notificationService = new Mock<INotificationService>();
+        notificationService.SetupSequence(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception())
+            .Returns(Task.CompletedTask);
+
+        var handler = new SendOverdueNotificationsHandler(loanRepository, notificationRepository, notificationService.Object);
+
+        // First attempt fails
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+        notificationRepository.Notifications.Single().Status.Should().Be(NotificationStatus.Pending);
+        notificationRepository.Notifications.Single().History.Should().HaveCount(1);
+        notificationRepository.Notifications.Single().History.First().Status.Should().Be(NotificationStatus.Failed);
+
+        // Second attempt succeeds
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+        notificationService.Verify(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        notificationRepository.Notifications.Single().Status.Should().Be(NotificationStatus.Sent);
+        notificationRepository.Notifications.Single().History.Should().HaveCount(2);
+        notificationRepository.Notifications.Single().History.Last().Status.Should().Be(NotificationStatus.Sent);
+    }
+
+    [Fact]
+    public async Task ShouldNotDuplicateNotifications_WhenRunMultipleTimes()
+    {
+        var loan = CreateOverdueLoan();
+        var loanRepository = new InMemoryLoanRepository(new[] { loan });
+        var notificationRepository = new InMemoryNotificationRepository();
+        var notificationService = new Mock<INotificationService>();
+        notificationService.Setup(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new SendOverdueNotificationsHandler(loanRepository, notificationRepository, notificationService.Object);
+
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+
+        notificationService.Verify(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()), Times.Once);
+        notificationRepository.Notifications.Should().HaveCount(1);
+        notificationRepository.Notifications.Single().History.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ShouldContinueProcessingAfterRestart_WhenNotificationsPending()
+    {
+        var loan = CreateOverdueLoan();
+        var loanRepository = new InMemoryLoanRepository(new[] { loan });
+        var notificationRepository = new InMemoryNotificationRepository();
+
+        var failingService = new Mock<INotificationService>();
+        failingService.Setup(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception());
+
+        var handler = new SendOverdueNotificationsHandler(loanRepository, notificationRepository, failingService.Object);
+        await handler.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+
+        notificationRepository.Notifications.Single().Status.Should().Be(NotificationStatus.Pending);
+
+        var successService = new Mock<INotificationService>();
+        successService.Setup(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handlerAfterRestart = new SendOverdueNotificationsHandler(loanRepository, notificationRepository, successService.Object);
+        await handlerAfterRestart.Handle(new SendOverdueNotificationsCommand(), CancellationToken.None);
+
+        successService.Verify(s => s.SendOverdueNotificationAsync(loan.Patron, loan, It.IsAny<CancellationToken>()), Times.Once);
+        notificationRepository.Notifications.Single().Status.Should().Be(NotificationStatus.Sent);
+    }
+
+    private class InMemoryNotificationRepository : IOverdueNotificationRepository
+    {
+        public List<OverdueNotification> Notifications { get; } = new();
+
+        public Task AddAsync(OverdueNotification notification, CancellationToken cancellationToken = default)
+        {
+            Notifications.Add(notification);
+            return Task.CompletedTask;
+        }
+
+        public Task<OverdueNotification?> GetByLoanIdAsync(Guid loanId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Notifications.SingleOrDefault(n => n.LoanId == loanId));
+        }
+
+        public Task UpdateAsync(OverdueNotification notification, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private class InMemoryLoanRepository : ILoanRepository
+    {
+        private readonly List<Loan> _loans;
+
+        public InMemoryLoanRepository(IEnumerable<Loan> loans)
+        {
+            _loans = loans.ToList();
+        }
+
+        public Task AddAsync(Loan loan, CancellationToken cancellationToken = default)
+        {
+            _loans.Add(loan);
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<Loan>> GetActiveLoansForPatronAsync(Guid patronId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_loans.Where(l => l.PatronId == patronId && !l.IsReturned));
+        }
+
+        public Task<IEnumerable<Loan>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_loans.Where(l => !l.IsReturned));
+        }
+
+        public Task<Loan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_loans.SingleOrDefault(l => l.Id == id));
+        }
+
+        public Task UpdateAsync(Loan loan, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add OverdueNotification entity with status history
- implement handler to send overdue notices and retry on failure
- cover overdue notification scenarios with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a865cd0734832196e2795862263d10