### PR TITLE
Add overdue book notification processing with retries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,5 +32,8 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+    <PackageVersion Include="DotNet.Testcontainers" Version="1.7.0-beta.2269" />
+    <PackageVersion Include="WireMock.Net" Version="1.5.32" />
   </ItemGroup>
 </Project>

--- a/LibraryLending.sln
+++ b/LibraryLending.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryLending.Application.Tests", "tests\LibraryLending.Application.Tests\LibraryLending.Application.Tests.csproj", "{59CA81FA-EE12-41B4-977A-B526016B6B3C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryLending.E2E.Tests", "tests\LibraryLending.E2E.Tests\LibraryLending.E2E.Tests.csproj", "{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,18 @@ Global
 		{59CA81FA-EE12-41B4-977A-B526016B6B3C}.Release|x64.Build.0 = Release|Any CPU
 		{59CA81FA-EE12-41B4-977A-B526016B6B3C}.Release|x86.ActiveCfg = Release|Any CPU
 		{59CA81FA-EE12-41B4-977A-B526016B6B3C}.Release|x86.Build.0 = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|x64.Build.0 = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Debug|x86.Build.0 = Debug|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|x64.ActiveCfg = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|x64.Build.0 = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|x86.ActiveCfg = Release|Any CPU
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,5 +111,6 @@ Global
 		{9FE6BF8E-18CC-400A-8775-A30A3C2BBEF6} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{86426122-EFDF-46C6-9257-FAA5579F3330} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{59CA81FA-EE12-41B4-977A-B526016B6B3C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{9EBD1F90-11F5-4396-AE60-F3B54B0A6560} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/LibraryLending.Application/DTOs/OverdueNotificationDto.cs
+++ b/src/LibraryLending.Application/DTOs/OverdueNotificationDto.cs
@@ -1,0 +1,3 @@
+namespace LibraryLending.Application.DTOs;
+
+public record OverdueNotificationDto(Guid LoanId, string Status);

--- a/src/LibraryLending.Application/Services/IEmailService.cs
+++ b/src/LibraryLending.Application/Services/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace LibraryLending.Application.Services;
+
+public interface IEmailService
+{
+    Task SendEmailAsync(string to, string subject, string body, CancellationToken cancellationToken = default);
+}

--- a/src/LibraryLending.Application/UseCases/Notifications/GetNotification/GetNotificationHandler.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/GetNotification/GetNotificationHandler.cs
@@ -1,0 +1,24 @@
+using LibraryLending.Application.DTOs;
+using LibraryLending.Domain.Repositories;
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.GetNotification;
+
+public class GetNotificationHandler : IRequestHandler<GetNotificationQuery, OverdueNotificationDto?>
+{
+    private readonly IOverdueNotificationRepository _repository;
+
+    public GetNotificationHandler(IOverdueNotificationRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<OverdueNotificationDto?> Handle(GetNotificationQuery request, CancellationToken cancellationToken)
+    {
+        var notification = await _repository.GetByLoanIdAsync(request.LoanId, cancellationToken);
+        if (notification is null)
+            return null;
+
+        return new OverdueNotificationDto(notification.LoanId, notification.Status.ToString());
+    }
+}

--- a/src/LibraryLending.Application/UseCases/Notifications/GetNotification/GetNotificationQuery.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/GetNotification/GetNotificationQuery.cs
@@ -1,0 +1,6 @@
+using LibraryLending.Application.DTOs;
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.GetNotification;
+
+public record GetNotificationQuery(Guid LoanId) : IRequest<OverdueNotificationDto?>;

--- a/src/LibraryLending.Application/UseCases/Notifications/ProcessOverdueNotifications/ProcessOverdueNotificationsCommand.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/ProcessOverdueNotifications/ProcessOverdueNotificationsCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.ProcessOverdueNotifications;
+
+public record ProcessOverdueNotificationsCommand() : IRequest;

--- a/src/LibraryLending.Application/UseCases/Notifications/ProcessOverdueNotifications/ProcessOverdueNotificationsHandler.cs
+++ b/src/LibraryLending.Application/UseCases/Notifications/ProcessOverdueNotifications/ProcessOverdueNotificationsHandler.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using LibraryLending.Application.Services;
+using LibraryLending.Domain.Entities;
+using LibraryLending.Domain.Enums;
+using LibraryLending.Domain.Repositories;
+using MediatR;
+
+namespace LibraryLending.Application.UseCases.Notifications.ProcessOverdueNotifications;
+
+public class ProcessOverdueNotificationsHandler : IRequestHandler<ProcessOverdueNotificationsCommand>
+{
+    private readonly ILoanRepository _loanRepository;
+    private readonly IOverdueNotificationRepository _notificationRepository;
+    private readonly IEmailService _emailService;
+
+    public ProcessOverdueNotificationsHandler(
+        ILoanRepository loanRepository,
+        IOverdueNotificationRepository notificationRepository,
+        IEmailService emailService)
+    {
+        _loanRepository = loanRepository;
+        _notificationRepository = notificationRepository;
+        _emailService = emailService;
+    }
+
+    public async Task<Unit> Handle(ProcessOverdueNotificationsCommand request, CancellationToken cancellationToken)
+    {
+        var overdueLoans = await _loanRepository.GetOverdueLoansAsync(cancellationToken);
+        foreach (var loan in overdueLoans)
+        {
+            var existing = await _notificationRepository.GetByLoanIdAsync(loan.Id, cancellationToken);
+            if (existing is null)
+            {
+                var notification = new OverdueNotification(loan.Id);
+                await _notificationRepository.AddAsync(notification, cancellationToken);
+            }
+        }
+
+        var pendingNotifications = await _notificationRepository.GetPendingAsync(cancellationToken);
+        foreach (var notification in pendingNotifications)
+        {
+            var loan = overdueLoans.FirstOrDefault(l => l.Id == notification.LoanId)
+                ?? await _loanRepository.GetByIdAsync(notification.LoanId, cancellationToken);
+            if (loan is null)
+                continue;
+
+            try
+            {
+                await _emailService.SendEmailAsync(
+                    loan.Patron.Email.Value,
+                    "Overdue book",
+                    $"Please return '{loan.Book.Title}'",
+                    cancellationToken);
+
+                notification.MarkSent(DateTime.UtcNow);
+                await _notificationRepository.UpdateAsync(notification, cancellationToken);
+            }
+            catch
+            {
+                // leave as pending for retry
+            }
+        }
+
+        return Unit.Value;
+    }
+}

--- a/src/LibraryLending.Domain/Entities/OverdueNotification.cs
+++ b/src/LibraryLending.Domain/Entities/OverdueNotification.cs
@@ -1,0 +1,28 @@
+using LibraryLending.Domain.Enums;
+
+namespace LibraryLending.Domain.Entities;
+
+public class OverdueNotification
+{
+    public Guid Id { get; private set; }
+    public Guid LoanId { get; private set; }
+    public NotificationStatus Status { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? SentAt { get; private set; }
+
+    private OverdueNotification() { }
+
+    public OverdueNotification(Guid loanId)
+    {
+        Id = Guid.NewGuid();
+        LoanId = loanId;
+        CreatedAt = DateTime.UtcNow;
+        Status = NotificationStatus.Pending;
+    }
+
+    public void MarkSent(DateTime sentAt)
+    {
+        Status = NotificationStatus.Sent;
+        SentAt = sentAt;
+    }
+}

--- a/src/LibraryLending.Domain/Enums/NotificationStatus.cs
+++ b/src/LibraryLending.Domain/Enums/NotificationStatus.cs
@@ -1,0 +1,7 @@
+namespace LibraryLending.Domain.Enums;
+
+public enum NotificationStatus
+{
+    Pending,
+    Sent
+}

--- a/src/LibraryLending.Domain/Repositories/ILoanRepository.cs
+++ b/src/LibraryLending.Domain/Repositories/ILoanRepository.cs
@@ -6,6 +6,7 @@ public interface ILoanRepository
 {
     Task<Loan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Loan>> GetActiveLoansForPatronAsync(Guid patronId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Loan>> GetOverdueLoansAsync(CancellationToken cancellationToken = default);
     Task AddAsync(Loan loan, CancellationToken cancellationToken = default);
     Task UpdateAsync(Loan loan, CancellationToken cancellationToken = default);
 }

--- a/src/LibraryLending.Domain/Repositories/IOverdueNotificationRepository.cs
+++ b/src/LibraryLending.Domain/Repositories/IOverdueNotificationRepository.cs
@@ -1,0 +1,10 @@
+using LibraryLending.Domain.Entities;
+namespace LibraryLending.Domain.Repositories;
+
+public interface IOverdueNotificationRepository
+{
+    Task<OverdueNotification?> GetByLoanIdAsync(Guid loanId, CancellationToken cancellationToken = default);
+    Task AddAsync(OverdueNotification notification, CancellationToken cancellationToken = default);
+    Task<IEnumerable<OverdueNotification>> GetPendingAsync(CancellationToken cancellationToken = default);
+    Task UpdateAsync(OverdueNotification notification, CancellationToken cancellationToken = default);
+}

--- a/src/LibraryLending.Infrastructure/Data/LibraryDbContext.cs
+++ b/src/LibraryLending.Infrastructure/Data/LibraryDbContext.cs
@@ -11,6 +11,7 @@ public class LibraryDbContext : DbContext
     public DbSet<Book> Books { get; set; } = null!;
     public DbSet<Patron> Patrons { get; set; } = null!;
     public DbSet<Loan> Loans { get; set; } = null!;
+    public DbSet<OverdueNotification> OverdueNotifications { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -126,6 +127,21 @@ public class LibraryDbContext : DbContext
             entity.HasIndex(e => e.BookId);
             entity.HasIndex(e => e.PatronId);
             entity.HasIndex(e => new { e.PatronId, e.ReturnedAt });
+        });
+
+        modelBuilder.Entity<OverdueNotification>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.ToTable("overdue_notifications");
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.LoanId).HasColumnName("loan_id").IsRequired();
+            entity.Property(e => e.Status)
+                .HasColumnName("status")
+                .HasConversion<string>()
+                .IsRequired();
+            entity.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
+            entity.Property(e => e.SentAt).HasColumnName("sent_at");
+            entity.HasIndex(e => e.LoanId).IsUnique();
         });
     }
 }

--- a/src/LibraryLending.Infrastructure/Repositories/LoanRepository.cs
+++ b/src/LibraryLending.Infrastructure/Repositories/LoanRepository.cs
@@ -32,6 +32,15 @@ public class LoanRepository : ILoanRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IEnumerable<Loan>> GetOverdueLoansAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Loans
+            .Include(l => l.Book)
+            .Include(l => l.Patron)
+            .Where(l => l.ReturnedAt == null && l.DueAt < DateTime.UtcNow)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task AddAsync(Loan loan, CancellationToken cancellationToken = default)
     {
         _context.Loans.Add(loan);

--- a/src/LibraryLending.Infrastructure/Repositories/OverdueNotificationRepository.cs
+++ b/src/LibraryLending.Infrastructure/Repositories/OverdueNotificationRepository.cs
@@ -1,0 +1,41 @@
+using LibraryLending.Domain.Entities;
+using LibraryLending.Domain.Enums;
+using LibraryLending.Domain.Repositories;
+using LibraryLending.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LibraryLending.Infrastructure.Repositories;
+
+public class OverdueNotificationRepository : IOverdueNotificationRepository
+{
+    private readonly LibraryDbContext _context;
+
+    public OverdueNotificationRepository(LibraryDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<OverdueNotification?> GetByLoanIdAsync(Guid loanId, CancellationToken cancellationToken = default)
+    {
+        return await _context.OverdueNotifications.FirstOrDefaultAsync(n => n.LoanId == loanId, cancellationToken);
+    }
+
+    public async Task AddAsync(OverdueNotification notification, CancellationToken cancellationToken = default)
+    {
+        _context.OverdueNotifications.Add(notification);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<OverdueNotification>> GetPendingAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.OverdueNotifications
+            .Where(n => n.Status == NotificationStatus.Pending)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(OverdueNotification notification, CancellationToken cancellationToken = default)
+    {
+        _context.OverdueNotifications.Update(notification);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/LibraryLending.Infrastructure/Services/EmailService.cs
+++ b/src/LibraryLending.Infrastructure/Services/EmailService.cs
@@ -1,0 +1,21 @@
+using LibraryLending.Application.Services;
+using System.Net.Http.Json;
+
+namespace LibraryLending.Infrastructure.Services;
+
+public class EmailService : IEmailService
+{
+    private readonly HttpClient _client;
+
+    public EmailService(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task SendEmailAsync(string to, string subject, string body, CancellationToken cancellationToken = default)
+    {
+        var payload = new { to, subject, body };
+        var response = await _client.PostAsJsonAsync("/send", payload, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/LibraryLending.WebApi/Controllers/NotificationsController.cs
+++ b/src/LibraryLending.WebApi/Controllers/NotificationsController.cs
@@ -1,0 +1,35 @@
+using LibraryLending.Application.DTOs;
+using LibraryLending.Application.UseCases.Notifications.GetNotification;
+using LibraryLending.Application.UseCases.Notifications.ProcessOverdueNotifications;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LibraryLending.WebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class NotificationsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public NotificationsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("overdue/process")]
+    public async Task<IActionResult> ProcessOverdue(CancellationToken cancellationToken)
+    {
+        await _mediator.Send(new ProcessOverdueNotificationsCommand(), cancellationToken);
+        return Ok();
+    }
+
+    [HttpGet("{loanId:guid}")]
+    public async Task<ActionResult<OverdueNotificationDto>> Get(Guid loanId, CancellationToken cancellationToken)
+    {
+        var notification = await _mediator.Send(new GetNotificationQuery(loanId), cancellationToken);
+        if (notification is null)
+            return NotFound();
+        return Ok(notification);
+    }
+}

--- a/src/LibraryLending.WebApi/Program.cs
+++ b/src/LibraryLending.WebApi/Program.cs
@@ -5,9 +5,11 @@ using LibraryLending.Application.UseCases.Loans.LoanBook;
 using LibraryLending.Application.UseCases.Loans.ReturnBook;
 using LibraryLending.Application.UseCases.Patrons.GetPatron;
 using LibraryLending.Application.UseCases.Patrons.RegisterPatron;
+using LibraryLending.Application.Services;
 using LibraryLending.Domain.Repositories;
 using LibraryLending.Infrastructure.Data;
 using LibraryLending.Infrastructure.Repositories;
+using LibraryLending.Infrastructure.Services;
 using LibraryLending.WebApi.Middleware;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -26,13 +28,28 @@ builder.Services.AddMediatR(typeof(RegisterPatronCommand).Assembly);
 builder.Services.AddValidatorsFromAssembly(typeof(RegisterPatronValidator).Assembly);
 
 // Add Entity Framework
-builder.Services.AddDbContext<LibraryDbContext>(options =>
-    options.UseInMemoryDatabase("LibraryLendingDb"));
+var connectionString = builder.Configuration.GetConnectionString("LibraryDb");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    builder.Services.AddDbContext<LibraryDbContext>(options =>
+        options.UseInMemoryDatabase("LibraryLendingDb"));
+}
+else
+{
+    builder.Services.AddDbContext<LibraryDbContext>(options =>
+        options.UseSqlServer(connectionString));
+}
 
 // Add repositories
 builder.Services.AddScoped<IBookRepository, BookRepository>();
 builder.Services.AddScoped<IPatronRepository, PatronRepository>();
 builder.Services.AddScoped<ILoanRepository, LoanRepository>();
+builder.Services.AddScoped<IOverdueNotificationRepository, OverdueNotificationRepository>();
+builder.Services.AddHttpClient<IEmailService, EmailService>(client =>
+{
+    var baseUrl = builder.Configuration["EmailService:BaseUrl"] ?? "http://localhost";
+    client.BaseAddress = new Uri(baseUrl);
+});
 
 var app = builder.Build();
 
@@ -85,3 +102,5 @@ static async Task SeedDataAsync(WebApplication app)
     
     await context.SaveChangesAsync();
 }
+
+public partial class Program { }

--- a/tests/LibraryLending.E2E.Tests/LibraryLending.E2E.Tests.csproj
+++ b/tests/LibraryLending.E2E.Tests/LibraryLending.E2E.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/LibraryLending.WebApi/LibraryLending.WebApi.csproj" />
+    <ProjectReference Include="../../src/LibraryLending.Domain/LibraryLending.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="DotNet.Testcontainers" />
+    <PackageReference Include="WireMock.Net" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/LibraryLending.E2E.Tests/NotificationApiFactory.cs
+++ b/tests/LibraryLending.E2E.Tests/NotificationApiFactory.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using LibraryLending.Infrastructure.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using WireMock.Server;
+
+namespace LibraryLending.E2E.Tests;
+
+public class NotificationApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly MsSqlTestcontainer _dbContainer = new TestcontainersBuilder<MsSqlTestcontainer>()
+        .WithDatabase(new MsSqlTestcontainerConfiguration { Password = "yourStrong(!)Password" })
+        .Build();
+    public WireMockServer EmailServer { get; } = WireMockServer.Start();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:LibraryDb"] = _dbContainer.ConnectionString,
+                ["EmailService:BaseUrl"] = EmailServer.Url
+            };
+            config.AddInMemoryCollection(settings);
+        });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LibraryDbContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        EmailServer.Stop();
+        await _dbContainer.DisposeAsync();
+    }
+}

--- a/tests/LibraryLending.E2E.Tests/OverdueNotificationsTests.cs
+++ b/tests/LibraryLending.E2E.Tests/OverdueNotificationsTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LibraryLending.Domain.Entities;
+using LibraryLending.Domain.ValueObjects;
+using LibraryLending.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace LibraryLending.E2E.Tests;
+
+public class OverdueNotificationsTests : IClassFixture<NotificationApiFactory>
+{
+    private readonly NotificationApiFactory _factory;
+
+    public OverdueNotificationsTests(NotificationApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task<Loan> SeedOverdueLoanAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LibraryDbContext>();
+        var book = new Book(Isbn.Create("9780132350884"), "Test", "Author", 1);
+        var patron = new Patron("Patron", Email.Create("patron@test.local"));
+        db.Books.Add(book);
+        db.Patrons.Add(patron);
+        var loan = new Loan(book.Id, patron.Id, DateTime.UtcNow.AddDays(-15)); // due yesterday
+        db.Loans.Add(loan);
+        await db.SaveChangesAsync();
+        return loan;
+    }
+
+    [Fact(DisplayName = "Сценарий 1: успешное уведомление")]
+    public async Task SuccessfulNotification()
+    {
+        var loan = await SeedOverdueLoanAsync();
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync("/notifications/overdue/process", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        _factory.EmailServer.LogEntries.Count().Should().Be(1);
+        var status = await client.GetFromJsonAsync<NotificationStatusDto>($"/notifications/{loan.Id}");
+        status!.Status.Should().Be("Sent");
+    }
+
+    [Fact(DisplayName = "Сценарий 2: временный сбой доставки")]
+    public async Task TemporaryFailureIsRetried()
+    {
+        var loan = await SeedOverdueLoanAsync();
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .InScenario("retry")
+            .WillSetStateTo("failed")
+            .RespondWith(Response.Create().WithStatusCode(500));
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .InScenario("retry")
+            .WhenStateIs("failed")
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var client = _factory.CreateClient();
+        var first = await client.PostAsync("/notifications/overdue/process", null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var status1 = await client.GetFromJsonAsync<NotificationStatusDto>($"/notifications/{loan.Id}");
+        status1!.Status.Should().Be("Pending");
+
+        var second = await client.PostAsync("/notifications/overdue/process", null);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        _factory.EmailServer.LogEntries.Count().Should().Be(2);
+        var status2 = await client.GetFromJsonAsync<NotificationStatusDto>($"/notifications/{loan.Id}");
+        status2!.Status.Should().Be("Sent");
+    }
+
+    [Fact(DisplayName = "Сценарий 3: отсутствие дублей")]
+    public async Task NoDuplicates()
+    {
+        var loan = await SeedOverdueLoanAsync();
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var client = _factory.CreateClient();
+        await client.PostAsync("/notifications/overdue/process", null);
+        await client.PostAsync("/notifications/overdue/process", null);
+        await client.PostAsync("/notifications/overdue/process", null);
+
+        _factory.EmailServer.LogEntries.Count().Should().Be(1);
+        var status = await client.GetFromJsonAsync<NotificationStatusDto>($"/notifications/{loan.Id}");
+        status!.Status.Should().Be("Sent");
+    }
+
+    [Fact(DisplayName = "Сценарий 4: устойчивость к перезапуску")]
+    public async Task ResilienceToRestart()
+    {
+        var loan = await SeedOverdueLoanAsync();
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .InScenario("restart")
+            .WillSetStateTo("failed")
+            .RespondWith(Response.Create().WithStatusCode(500));
+        _factory.EmailServer
+            .Given(Request.Create().WithPath("/send").UsingPost())
+            .InScenario("restart")
+            .WhenStateIs("failed")
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var client = _factory.CreateClient();
+        await client.PostAsync("/notifications/overdue/process", null);
+
+        // simulate restart
+        await _factory.DisposeAsync();
+        var newFactory = new NotificationApiFactory();
+        await newFactory.InitializeAsync();
+        var newClient = newFactory.CreateClient();
+
+        var second = await newClient.PostAsync("/notifications/overdue/process", null);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        newFactory.EmailServer.LogEntries.Count().Should().Be(2);
+        var status = await newClient.GetFromJsonAsync<NotificationStatusDto>($"/notifications/{loan.Id}");
+        status!.Status.Should().Be("Sent");
+
+        await newFactory.DisposeAsync();
+    }
+}
+
+public record NotificationStatusDto(Guid LoanId, string Status);


### PR DESCRIPTION
## Summary
- add API and background logic to send overdue loan email notifications with retry and dedupe
- introduce email service and persistence for pending notifications
- cover scenarios with end-to-end tests using Testcontainers and WireMock

## Testing
- `MSBUILDTERMINALLOGGER=OFF dotnet test` *(fails: Connection failed - Cannot assign requested address)*

------
https://chatgpt.com/codex/tasks/task_e_68a865d3cd7c83218eac1524f20b44a1